### PR TITLE
JSONで返すAPIを実装する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,9 @@ dependencies = [
  "actix-web 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 [dependencies]
 actix-web = "1.0"
 diesel = { version = "1.4.3", features = ["sqlite"] }
+serde = "1.0.102"
+serde_derive = "1.0.102"
+serde_json = "1.0.41"
 
 [dev-dependencies]
 bytes = "0.4.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["sinsoku <sinsoku.listy@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 actix-web = "1.0"
 diesel = { version = "1.4.3", features = ["sqlite"] }

--- a/src/controllers/posts.rs
+++ b/src/controllers/posts.rs
@@ -2,7 +2,7 @@ use crate::models::Post;
 use actix_web::{HttpRequest, HttpResponse, Responder};
 
 pub fn index() -> impl Responder {
-    let results = Post::all();
+    let results = Post::published_all();
     let res = format!("Displaying {} posts", results.len());
 
     HttpResponse::Ok().body(res)
@@ -11,6 +11,13 @@ pub fn index() -> impl Responder {
 pub fn show(req: HttpRequest) -> impl Responder {
     let post = find_post(req);
     let res = format!("Show {}", post.id);
+
+    HttpResponse::Ok().body(res)
+}
+
+pub fn show_json(req: HttpRequest) -> impl Responder {
+    let post = find_post(req);
+    let res = serde_json::to_string(&post).unwrap();
 
     HttpResponse::Ok().body(res)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate diesel;
+extern crate serde_derive;
 
 pub mod controllers;
 pub mod models;

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -2,8 +2,9 @@ use super::util::establish_connection;
 use crate::schema::posts;
 use crate::schema::posts::dsl;
 use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
 
-#[derive(Queryable)]
+#[derive(Queryable, Serialize, Deserialize)]
 pub struct Post {
     pub id: i32,
     pub title: String,
@@ -20,6 +21,13 @@ struct NewPost<'a> {
 
 impl Post {
     pub fn all() -> Vec<Post> {
+        let connection = establish_connection();
+        dsl::posts
+            .load::<Post>(&connection)
+            .expect("Error loading posts")
+    }
+
+    pub fn published_all() -> Vec<Post> {
         let connection = establish_connection();
         dsl::posts
             .filter(dsl::published.eq(true))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,6 +7,7 @@ pub fn top(cfg: &mut web::ServiceConfig) {
 
 pub fn posts(cfg: &mut web::ServiceConfig) {
     cfg.route("/posts", web::get().to(posts::index))
+        .route("/posts/{id}.json", web::get().to(posts::show_json))
         .route("/posts/{id}", web::get().to(posts::show))
         .route("/posts", web::post().to(posts::create))
         .route("/posts/{id}", web::put().to(posts::update))

--- a/tests/posts.rs
+++ b/tests/posts.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+mod tests {
+    extern crate rust_web;
+
+    use actix_web::dev::Service;
+    use actix_web::http::StatusCode;
+    use actix_web::{test, App};
+    use rust_web::models::Post;
+    use rust_web::routes;
+
+    #[test]
+    fn get_posts_json() {
+        Post::create("a", "b");
+        let posts = Post::all();
+        let post = posts.last().unwrap();
+        let uri = format!("/posts/{}.json", post.id);
+
+        let mut app =
+            test::init_service(App::new().configure(routes::top).configure(routes::posts));
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp = test::block_on(app.call(req)).unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json_u8 = test::read_body(resp).to_vec();
+        let json = unsafe { String::from_utf8_unchecked(json_u8) };
+        let json_post: Post = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(json_post.id, post.id);
+        assert_eq!(json_post.title, "a");
+        assert_eq!(json_post.body, "b");
+
+        post.destroy();
+    }
+}


### PR DESCRIPTION
[serde_json](https://github.com/serde-rs/json)を使ってJSONを返すAPIを実装した。

ルーティングが前方一致なので、`"/posts/{id}"`の前に書く必要がある。